### PR TITLE
Ignore automatically generated Vim helptags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+doc/tags
+doc/tags-te


### PR DESCRIPTION
We don't need to track generated helptags.
